### PR TITLE
Allow full transparency of the background rectangle.

### DIFF
--- a/package/config/config.qml
+++ b/package/config/config.qml
@@ -177,7 +177,7 @@ ColumnLayout {
 
                 leftPadding: 0
                 value: indicator.configuration.maxBackgroundOpacity * 100
-                from: 20
+                from: 0
                 to: 100
                 stepSize: 5
                 wheelEnabled: false

--- a/package/ui/main.qml
+++ b/package/ui/main.qml
@@ -73,18 +73,22 @@ LatteComponents.IndicatorItem {
                 return 0.25;
             } else if (indicator.configuration.maxBackgroundOpacity >= 0.3) {
                 return 0.12;
+            } else if (indicator.configuration.maxBackgroundOpacity >= 0.05) {
+                return 0.05;
             }
-
-            return 0.05;
+            
+            return 0;
         }
 
         opacity: {
-            if (indicator.isHovered && indicator.hasActive) {
-                return indicator.configuration.maxBackgroundOpacity;
-            } else if (indicator.hasActive) {
-                return indicator.configuration.maxBackgroundOpacity - opacityStep;
-            } else if (indicator.isHovered) {
-                return indicator.configuration.maxBackgroundOpacity - 2*opacityStep;
+            if (indicator.configuration.maxBackgroundOpacity != 0) {
+                if (indicator.isHovered && indicator.hasActive) {
+                    return indicator.configuration.maxBackgroundOpacity;
+                } else if (indicator.hasActive) {
+                    return indicator.configuration.maxBackgroundOpacity - opacityStep;
+                } else if (indicator.isHovered) {
+                    return indicator.configuration.maxBackgroundOpacity - 2*opacityStep;
+                }
             }
 
             return 0;


### PR DESCRIPTION
I just found this indicator plugin yesterday and I really like it!  I wanted to be able to make the background rectangle entirely transparent though; so I figured I would try doing it myself and resolve the [single open issue this project has](https://github.com/psifidotos/latte-indicator-dashtopanel/issues/4). 