### PR TITLE
Added option to toggle the metro shading for all styles.

### DIFF
--- a/package/config/config.qml
+++ b/package/config/config.qml
@@ -289,5 +289,17 @@ ColumnLayout {
                 indicator.configuration.isReversed = !indicator.configuration.isReversed;
             }
         }
+        
+        LatteComponents.CheckBox {
+            Layout.maximumWidth: dialog.optionsWidth
+            text: i18n("Shade indicators")
+            checked: indicator.configuration.enableCounterShading
+            tooltip: i18n("Indicators past the first are shaded")
+            visible: deprecatedPropertiesAreHidden        
+
+            onClicked: {
+                indicator.configuration.enableCounterShading = !indicator.configuration.enableCounterShading;
+            }
+        }
     }
 }

--- a/package/config/main.xml
+++ b/package/config/main.xml
@@ -28,5 +28,8 @@
     <entry name="lengthPadding" type="Double">
         <default>0.10</default>
     </entry>
+    <entry name="enableCounterShading" type="Bool">
+        <default>true</default>
+    </entry> 
   </group>
 </kcfg>

--- a/package/ui/main.qml
+++ b/package/ui/main.qml
@@ -57,6 +57,13 @@ LatteComponents.IndicatorItem {
         when: root.hasOwnProperty("lengthPadding")
         value: indicator.configuration.lengthPadding
     }
+    
+    Binding{
+        target: root
+        property: "enableCounterShading"
+        when: root.hasOwnProperty("enableCounterShading")
+        value: indicator.configuration.enableCounterShading
+    }
 
     //! Background
     Rectangle {
@@ -134,7 +141,7 @@ LatteComponents.IndicatorItem {
                 Layout.minimumHeight: isHorizontal ? boxesLayout.thickness : boxesLayout.minLength
                 Layout.maximumHeight: isVertical && isFirst ? -1 : (isVertical ? boxesLayout.minLength : boxesLayout.thickness)
 
-                color: isMetroStyle && !isFirst ? indicator.iconBackgroundColor : indicator.iconGlowColor
+                color: indicator.configuration.enableCounterShading && !isFirst ? indicator.iconBackgroundColor : indicator.iconGlowColor
 
                 readonly property bool isFirst: index === 0
             }


### PR DESCRIPTION
I really liked how the Metro style shaded all indicators past the first one, but I wanted that effect combined with how Ciliora and Dashes keep track of the window instances.  So I added a toggle checkbox for it!